### PR TITLE
fix(post image): stop using base64

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -49,6 +49,7 @@ class BlogPostTemplate extends React.Component {
               <Img
                 fluid={post.frontmatter.featuredImage.childImageSharp.fluid}
                 alt={post.frontmatter.featuredImageDescription || ''}
+                critical={true}
               />
             )}
           </header>
@@ -117,7 +118,7 @@ export const pageQuery = graphql`
         featuredImage {
           childImageSharp {
             fluid(maxWidth: 800) {
-              ...GatsbyImageSharpFluid
+              ...GatsbyImageSharpFluid_noBase64
             }
           }
         }


### PR DESCRIPTION
This PR removes base64 encoded version of the featured image as it's been causing issues with the linkedin preview